### PR TITLE
Adding Barcode field update functions

### DIFF
--- a/SpecifyStorageTreeUpdateTool/App.config
+++ b/SpecifyStorageTreeUpdateTool/App.config
@@ -33,6 +33,9 @@
       <setting name="SpecifyCollectionName" serializeAs="String">
         <value />
       </setting>
+      <setting name="StorageBarcodeField" serializeAs="String">
+        <value>number1</value>
+      </setting>
     </SpecifyStorageTreeUpdateTool.Properties.Settings>
   </userSettings>
 </configuration>

--- a/SpecifyStorageTreeUpdateTool/Classes/SpecifyTools.cs
+++ b/SpecifyStorageTreeUpdateTool/Classes/SpecifyTools.cs
@@ -24,6 +24,7 @@ namespace SpecifyStorageTreeUpdateTool
         private string masterUsername;
         private string masterPassword;
         private bool loggingEnabled;
+        private string storageBarcodeField;
 
         public bool IsConnected { get { return isConnected; } }
         public bool IsAuthorized { get { return isAuthorized; } }
@@ -35,6 +36,10 @@ namespace SpecifyStorageTreeUpdateTool
         public bool LoggingEnabled {
             get { return loggingEnabled; }
             set { loggingEnabled = value; }
+        }
+        public string StorageBarcodeFieldName { 
+            get { return storageBarcodeField; } 
+            set { storageBarcodeField = value; }    
         }
 
         public SpecifyTools()
@@ -68,6 +73,15 @@ namespace SpecifyStorageTreeUpdateTool
                     {
                         this.collectionName = collectionName;
                         isAuthorized = true;
+                    }
+                    if (Properties.Settings.Default.StorageBarcodeField == String.Empty)
+                    {
+                        Properties.Settings.Default.StorageBarcodeField = "number1";
+                        storageBarcodeField = "number1";
+                    }
+                    else
+                    {
+                        storageBarcodeField = Properties.Settings.Default.StorageBarcodeField;
                     }
                 }
             }
@@ -472,6 +486,45 @@ namespace SpecifyStorageTreeUpdateTool
                     cmd.Parameters.AddWithValue("@storageId", storageId);
                     cmd.Parameters.AddWithValue("@agentID", agentID);
                     cmd.Parameters.AddWithValue("@prepGUID", prepGUID);
+                    cmd.ExecuteNonQuery();
+                    return true;
+                }
+                catch (MySqlException ex)
+                {
+                    MessageBox.Show(ex.ToString());
+                }
+            }
+            return false;
+        }
+
+        public bool UpdatePrepBarcodes()
+        {
+            if (isConnected)
+            {
+                try
+                {
+                    string sql = "UPDATE preparation SET Barcode = PreparationID WHERE CollectionMemberID = @CollectionID AND Barcode IS NULL";
+                    MySqlCommand cmd = new MySqlCommand(sql, conn);
+                    cmd.Parameters.AddWithValue("@CollectionID", collectionID);
+                    cmd.ExecuteNonQuery();
+                    return true;
+                }
+                catch (MySqlException ex)
+                {
+                    MessageBox.Show(ex.ToString());
+                }
+            }
+            return false;
+        }
+
+        public bool UpdateStorageBarcodes()
+        {
+            if (isConnected)
+            {
+                try
+                {
+                    string sql = "UPDATE storage SET " + storageBarcodeField + " = StorageID WHERE " + storageBarcodeField + " IS NULL";
+                    MySqlCommand cmd = new MySqlCommand(sql, conn);
                     cmd.ExecuteNonQuery();
                     return true;
                 }

--- a/SpecifyStorageTreeUpdateTool/Forms/ConfigForm.Designer.cs
+++ b/SpecifyStorageTreeUpdateTool/Forms/ConfigForm.Designer.cs
@@ -36,6 +36,8 @@
             this.MasterUserNameTextBox = new System.Windows.Forms.TextBox();
             this.MasterPasswordTextBox = new System.Windows.Forms.TextBox();
             this.CreateTableEnableLogginButton = new System.Windows.Forms.Button();
+            this.lblStorageBarcodeField = new System.Windows.Forms.Label();
+            this.tbStorageBarcodeField = new System.Windows.Forms.TextBox();
             this.SuspendLayout();
             // 
             // WelcomeLabel
@@ -52,7 +54,7 @@
             // 
             this.enableAuditLogCheckbox.AutoSize = true;
             this.enableAuditLogCheckbox.Font = new System.Drawing.Font("Microsoft Sans Serif", 14.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.enableAuditLogCheckbox.Location = new System.Drawing.Point(47, 85);
+            this.enableAuditLogCheckbox.Location = new System.Drawing.Point(47, 140);
             this.enableAuditLogCheckbox.Name = "enableAuditLogCheckbox";
             this.enableAuditLogCheckbox.Size = new System.Drawing.Size(316, 28);
             this.enableAuditLogCheckbox.TabIndex = 1;
@@ -63,7 +65,7 @@
             // btnClose
             // 
             this.btnClose.Font = new System.Drawing.Font("Microsoft Sans Serif", 14.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.btnClose.Location = new System.Drawing.Point(341, 303);
+            this.btnClose.Location = new System.Drawing.Point(341, 358);
             this.btnClose.Name = "btnClose";
             this.btnClose.Size = new System.Drawing.Size(105, 39);
             this.btnClose.TabIndex = 2;
@@ -75,7 +77,7 @@
             // 
             this.MasterUserNameLabel.AutoSize = true;
             this.MasterUserNameLabel.Font = new System.Drawing.Font("Microsoft Sans Serif", 14.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.MasterUserNameLabel.Location = new System.Drawing.Point(47, 142);
+            this.MasterUserNameLabel.Location = new System.Drawing.Point(47, 197);
             this.MasterUserNameLabel.Name = "MasterUserNameLabel";
             this.MasterUserNameLabel.Size = new System.Drawing.Size(158, 24);
             this.MasterUserNameLabel.TabIndex = 3;
@@ -86,7 +88,7 @@
             // 
             this.MasterPasswordLabel.AutoSize = true;
             this.MasterPasswordLabel.Font = new System.Drawing.Font("Microsoft Sans Serif", 14.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.MasterPasswordLabel.Location = new System.Drawing.Point(47, 189);
+            this.MasterPasswordLabel.Location = new System.Drawing.Point(47, 244);
             this.MasterPasswordLabel.Name = "MasterPasswordLabel";
             this.MasterPasswordLabel.Size = new System.Drawing.Size(153, 24);
             this.MasterPasswordLabel.TabIndex = 4;
@@ -96,7 +98,7 @@
             // MasterUserNameTextBox
             // 
             this.MasterUserNameTextBox.Font = new System.Drawing.Font("Microsoft Sans Serif", 14.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.MasterUserNameTextBox.Location = new System.Drawing.Point(222, 140);
+            this.MasterUserNameTextBox.Location = new System.Drawing.Point(222, 195);
             this.MasterUserNameTextBox.Name = "MasterUserNameTextBox";
             this.MasterUserNameTextBox.Size = new System.Drawing.Size(224, 29);
             this.MasterUserNameTextBox.TabIndex = 5;
@@ -105,7 +107,7 @@
             // MasterPasswordTextBox
             // 
             this.MasterPasswordTextBox.Font = new System.Drawing.Font("Microsoft Sans Serif", 14.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.MasterPasswordTextBox.Location = new System.Drawing.Point(222, 187);
+            this.MasterPasswordTextBox.Location = new System.Drawing.Point(222, 242);
             this.MasterPasswordTextBox.Name = "MasterPasswordTextBox";
             this.MasterPasswordTextBox.Size = new System.Drawing.Size(224, 29);
             this.MasterPasswordTextBox.TabIndex = 6;
@@ -115,7 +117,7 @@
             // CreateTableEnableLogginButton
             // 
             this.CreateTableEnableLogginButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 14.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.CreateTableEnableLogginButton.Location = new System.Drawing.Point(69, 236);
+            this.CreateTableEnableLogginButton.Location = new System.Drawing.Point(69, 291);
             this.CreateTableEnableLogginButton.Name = "CreateTableEnableLogginButton";
             this.CreateTableEnableLogginButton.Size = new System.Drawing.Size(377, 39);
             this.CreateTableEnableLogginButton.TabIndex = 7;
@@ -124,11 +126,31 @@
             this.CreateTableEnableLogginButton.Visible = false;
             this.CreateTableEnableLogginButton.Click += new System.EventHandler(this.CreateTableEnableLogginButton_Click);
             // 
+            // lblStorageBarcodeField
+            // 
+            this.lblStorageBarcodeField.AutoSize = true;
+            this.lblStorageBarcodeField.Font = new System.Drawing.Font("Microsoft Sans Serif", 14.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lblStorageBarcodeField.Location = new System.Drawing.Point(47, 89);
+            this.lblStorageBarcodeField.Name = "lblStorageBarcodeField";
+            this.lblStorageBarcodeField.Size = new System.Drawing.Size(198, 24);
+            this.lblStorageBarcodeField.TabIndex = 8;
+            this.lblStorageBarcodeField.Text = "Storage Barcode Field";
+            // 
+            // tbStorageBarcodeField
+            // 
+            this.tbStorageBarcodeField.Font = new System.Drawing.Font("Microsoft Sans Serif", 14.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.tbStorageBarcodeField.Location = new System.Drawing.Point(251, 86);
+            this.tbStorageBarcodeField.Name = "tbStorageBarcodeField";
+            this.tbStorageBarcodeField.Size = new System.Drawing.Size(195, 29);
+            this.tbStorageBarcodeField.TabIndex = 9;
+            // 
             // ConfigForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(590, 437);
+            this.Controls.Add(this.tbStorageBarcodeField);
+            this.Controls.Add(this.lblStorageBarcodeField);
             this.Controls.Add(this.CreateTableEnableLogginButton);
             this.Controls.Add(this.MasterPasswordTextBox);
             this.Controls.Add(this.MasterUserNameTextBox);
@@ -138,7 +160,7 @@
             this.Controls.Add(this.enableAuditLogCheckbox);
             this.Controls.Add(this.WelcomeLabel);
             this.Name = "ConfigForm";
-            this.Text = "Configuation";
+            this.Text = " ";
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -154,5 +176,7 @@
         private System.Windows.Forms.TextBox MasterUserNameTextBox;
         private System.Windows.Forms.TextBox MasterPasswordTextBox;
         private System.Windows.Forms.Button CreateTableEnableLogginButton;
+        private System.Windows.Forms.Label lblStorageBarcodeField;
+        private System.Windows.Forms.TextBox tbStorageBarcodeField;
     }
 }

--- a/SpecifyStorageTreeUpdateTool/Forms/ConfigForm.cs
+++ b/SpecifyStorageTreeUpdateTool/Forms/ConfigForm.cs
@@ -25,12 +25,16 @@ namespace SpecifyStorageTreeUpdateTool.Forms
             InitializeComponent();
             this.sp = sp;
             enableAuditLogCheckbox.Checked = sp.LoggingEnabled;
+            tbStorageBarcodeField.Text = sp.StorageBarcodeFieldName;
             initDone = true;
             
         }
 
         private void btnClose_Click(object sender, EventArgs e)
         {
+            sp.StorageBarcodeFieldName = tbStorageBarcodeField.Text;
+            Properties.Settings.Default.StorageBarcodeField = sp.StorageBarcodeFieldName;
+            Properties.Settings.Default.Save(); 
             this.Close();
         }
 

--- a/SpecifyStorageTreeUpdateTool/Forms/Scanning.Designer.cs
+++ b/SpecifyStorageTreeUpdateTool/Forms/Scanning.Designer.cs
@@ -45,6 +45,7 @@
             this.statusStrip1 = new System.Windows.Forms.StatusStrip();
             this.toolStripStatusSpacer = new System.Windows.Forms.ToolStripStatusLabel();
             this.toolStripStatusUserName = new System.Windows.Forms.ToolStripStatusLabel();
+            this.toolStripStatusLabelCollection = new System.Windows.Forms.ToolStripStatusLabel();
             this.toolStripStatusDatabase = new System.Windows.Forms.ToolStripStatusLabel();
             this.toolStripStatusServer = new System.Windows.Forms.ToolStripStatusLabel();
             this.lblInfo = new System.Windows.Forms.Label();
@@ -53,7 +54,8 @@
             this.lblScanCount = new System.Windows.Forms.Label();
             this.lblError = new System.Windows.Forms.Label();
             this.lblTitle = new System.Windows.Forms.Label();
-            this.toolStripStatusLabelCollection = new System.Windows.Forms.ToolStripStatusLabel();
+            this.updatePrepBarcodesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.updateStorageBarcodesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.menuStrip1.SuspendLayout();
             this.statusStrip1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer)).BeginInit();
@@ -100,7 +102,9 @@
             // systemToolStripMenuItem
             // 
             this.systemToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.configToolStripMenuItem});
+            this.configToolStripMenuItem,
+            this.updatePrepBarcodesToolStripMenuItem,
+            this.updateStorageBarcodesToolStripMenuItem});
             this.systemToolStripMenuItem.Name = "systemToolStripMenuItem";
             this.systemToolStripMenuItem.Size = new System.Drawing.Size(57, 20);
             this.systemToolStripMenuItem.Text = "System";
@@ -108,7 +112,7 @@
             // configToolStripMenuItem
             // 
             this.configToolStripMenuItem.Name = "configToolStripMenuItem";
-            this.configToolStripMenuItem.Size = new System.Drawing.Size(110, 22);
+            this.configToolStripMenuItem.Size = new System.Drawing.Size(190, 22);
             this.configToolStripMenuItem.Text = "Config";
             this.configToolStripMenuItem.Click += new System.EventHandler(this.configToolStripMenuItem_Click);
             // 
@@ -189,7 +193,7 @@
             | System.Windows.Forms.ToolStripStatusLabelBorderSides.Right) 
             | System.Windows.Forms.ToolStripStatusLabelBorderSides.Bottom)));
             this.toolStripStatusSpacer.Name = "toolStripStatusSpacer";
-            this.toolStripStatusSpacer.Size = new System.Drawing.Size(798, 19);
+            this.toolStripStatusSpacer.Size = new System.Drawing.Size(825, 19);
             this.toolStripStatusSpacer.Spring = true;
             this.toolStripStatusSpacer.Text = "    ";
             this.toolStripStatusSpacer.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
@@ -204,6 +208,15 @@
             this.toolStripStatusUserName.Size = new System.Drawing.Size(66, 19);
             this.toolStripStatusUserName.Text = "UserName";
             this.toolStripStatusUserName.ToolTipText = "Current User Name";
+            // 
+            // toolStripStatusLabelCollection
+            // 
+            this.toolStripStatusLabelCollection.BorderSides = ((System.Windows.Forms.ToolStripStatusLabelBorderSides)((((System.Windows.Forms.ToolStripStatusLabelBorderSides.Left | System.Windows.Forms.ToolStripStatusLabelBorderSides.Top) 
+            | System.Windows.Forms.ToolStripStatusLabelBorderSides.Right) 
+            | System.Windows.Forms.ToolStripStatusLabelBorderSides.Bottom)));
+            this.toolStripStatusLabelCollection.Name = "toolStripStatusLabelCollection";
+            this.toolStripStatusLabelCollection.Size = new System.Drawing.Size(65, 19);
+            this.toolStripStatusLabelCollection.Text = "Collection";
             // 
             // toolStripStatusDatabase
             // 
@@ -229,10 +242,10 @@
             this.lblInfo.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.lblInfo.Location = new System.Drawing.Point(369, 119);
             this.lblInfo.Name = "lblInfo";
-            this.lblInfo.Size = new System.Drawing.Size(613, 16);
+            this.lblInfo.Size = new System.Drawing.Size(610, 16);
             this.lblInfo.TabIndex = 11;
             this.lblInfo.Text = "Shelf labels are storage.StorageID with a prefix of \"SHELF\". Prep lables are prep" +
-    "aration.PreparationID.";
+    "aration.PreparationID";
             // 
             // lblStatus
             // 
@@ -298,14 +311,19 @@
             this.lblTitle.TabIndex = 2;
             this.lblTitle.Text = "Specify Storage Tree Update Tool";
             // 
-            // toolStripStatusLabelCollection
+            // updatePrepBarcodesToolStripMenuItem
             // 
-            this.toolStripStatusLabelCollection.BorderSides = ((System.Windows.Forms.ToolStripStatusLabelBorderSides)((((System.Windows.Forms.ToolStripStatusLabelBorderSides.Left | System.Windows.Forms.ToolStripStatusLabelBorderSides.Top) 
-            | System.Windows.Forms.ToolStripStatusLabelBorderSides.Right) 
-            | System.Windows.Forms.ToolStripStatusLabelBorderSides.Bottom)));
-            this.toolStripStatusLabelCollection.Name = "toolStripStatusLabelCollection";
-            this.toolStripStatusLabelCollection.Size = new System.Drawing.Size(65, 19);
-            this.toolStripStatusLabelCollection.Text = "Collection";
+            this.updatePrepBarcodesToolStripMenuItem.Name = "updatePrepBarcodesToolStripMenuItem";
+            this.updatePrepBarcodesToolStripMenuItem.Size = new System.Drawing.Size(190, 22);
+            this.updatePrepBarcodesToolStripMenuItem.Text = "Update Prep Barcodes";
+            this.updatePrepBarcodesToolStripMenuItem.Click += new System.EventHandler(this.updatePrepBarcodesToolStripMenuItem_Click);
+            // 
+            // updateStorageBarcodesToolStripMenuItem
+            // 
+            this.updateStorageBarcodesToolStripMenuItem.Name = "updateStorageBarcodesToolStripMenuItem";
+            this.updateStorageBarcodesToolStripMenuItem.Size = new System.Drawing.Size(203, 22);
+            this.updateStorageBarcodesToolStripMenuItem.Text = "UpdateStorage Barcodes";
+            this.updateStorageBarcodesToolStripMenuItem.Click += new System.EventHandler(this.updateStorageBarcodesToolStripMenuItem_Click);
             // 
             // Scanning
             // 
@@ -361,6 +379,8 @@
         private System.Windows.Forms.ToolStripMenuItem configToolStripMenuItem;
         private System.Windows.Forms.Label lblScanCount;
         private System.Windows.Forms.ToolStripStatusLabel toolStripStatusLabelCollection;
+        private System.Windows.Forms.ToolStripMenuItem updatePrepBarcodesToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem updateStorageBarcodesToolStripMenuItem;
     }
 }
 

--- a/SpecifyStorageTreeUpdateTool/Forms/Scanning.cs
+++ b/SpecifyStorageTreeUpdateTool/Forms/Scanning.cs
@@ -144,5 +144,29 @@ namespace SpecifyStorageTreeUpdateTool
             Forms.ConfigForm cf = new Forms.ConfigForm(sp);
             cf.ShowDialog();
         }
+
+        private void updatePrepBarcodesToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            if (sp.UpdatePrepBarcodes())
+            {
+                MessageBox.Show("Empty preparation barcodes filled.Yum!");
+            }
+            else
+            {
+                MessageBox.Show("Failed to update empty preparation barcodes. Might want to check on that.");
+            }
+        }
+
+        private void updateStorageBarcodesToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            if (sp.UpdateStorageBarcodes())
+            {
+                MessageBox.Show("Empty storage node barcodes filled. Yum!");
+            }
+            else
+            {
+                MessageBox.Show("Failed to update empty storage barcodes. Might want to check on that. Is the field set correctly in config?");
+            }
+        }
     }
 }

--- a/SpecifyStorageTreeUpdateTool/Properties/Settings.Designer.cs
+++ b/SpecifyStorageTreeUpdateTool/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace SpecifyStorageTreeUpdateTool.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.0.3.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.1.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -80,6 +80,18 @@ namespace SpecifyStorageTreeUpdateTool.Properties {
             }
             set {
                 this["SpecifyCollectionName"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("number1")]
+        public string StorageBarcodeField {
+            get {
+                return ((string)(this["StorageBarcodeField"]));
+            }
+            set {
+                this["StorageBarcodeField"] = value;
             }
         }
     }

--- a/SpecifyStorageTreeUpdateTool/Properties/Settings.settings
+++ b/SpecifyStorageTreeUpdateTool/Properties/Settings.settings
@@ -17,5 +17,8 @@
     <Setting Name="SpecifyCollectionName" Type="System.String" Scope="User">
       <Value Profile="(Default)" />
     </Setting>
+    <Setting Name="StorageBarcodeField" Type="System.String" Scope="User">
+      <Value Profile="(Default)">number1</Value>
+    </Setting>
   </Settings>
 </SettingsFile>


### PR DESCRIPTION
Added functions to update the barcode fields on storage and preparation. Added config to store storage barcode field name. These functions copy the table's ID into the field, barcode for preparation and whatever is in the config for storage. This is necessary to put the ID in a field the Specify query tool may access to generate labels. 

Sadly, adding an after insert trigger to the table to perform this action causes Specify to crash spectacularly. 